### PR TITLE
修复官方v0.2.0分支setBadgeNumber找不到符号的问题

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -34,7 +34,7 @@ android {
 }
 
 dependencies {
-    implementation 'cn.jiguang.sdk:jpush:3.3.4'
+    implementation 'cn.jiguang.sdk:jpush:3.3.9'
     implementation 'cn.jiguang.sdk:jcore:2.1.2'
 //    implementation 'com.android.support:appcompat-v7:28.+'
     compileOnly files('libs/flutter.jar')


### PR DESCRIPTION
v0.2.0版本使用了jpush3.3.6以后才支持setBadgeNumber，而gradle里jpush的版本依然是3.3.4，所以导致build失败。升级到最新jpush版本后解决。