### PR TITLE
增加 proguard 混淆默认规则

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -27,7 +27,9 @@ android {
     defaultConfig {
         minSdkVersion 17
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
+        consumerProguardFiles 'consumer-rules.pro'
     }
+
     lintOptions {
         disable 'InvalidPackage'
     }

--- a/android/consumer-rules.pro
+++ b/android/consumer-rules.pro
@@ -1,0 +1,14 @@
+# 极光推送
+-dontoptimize
+-dontpreverify
+
+-dontwarn cn.jpush.**
+-keep class cn.jpush.** { *; }
+-keep class * extends cn.jpush.android.helpers.JPushMessageReceiver { *; }
+
+-dontwarn cn.jiguang.**
+-keep class cn.jiguang.** { *; }
+
+-dontwarn com.google.**
+-keep class com.google.gson.** {*;}
+-keep class com.google.protobuf.** {*;}


### PR DESCRIPTION
配置后集成时无需开发者手动配置混淆。ref: http://docs.jiguang.cn/jpush/client/Android/android_guide/#_7