### PR TITLE
修复由于FlutterEngine detach 造成的空指针

### DIFF
--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.5-all.zip

--- a/android/src/main/java/com/jiguang/jpush/JPushEventReceiver.java
+++ b/android/src/main/java/com/jiguang/jpush/JPushEventReceiver.java
@@ -23,47 +23,57 @@ import io.flutter.plugin.common.MethodChannel.Result;
 public class JPushEventReceiver extends JPushMessageService {
 
     @Override
-    public void onNotifyMessageUnShow(Context context,final NotificationMessage notificationMessage) {
-        super.onNotifyMessageUnShow(context,notificationMessage);
+    public void onNotifyMessageUnShow(Context context, final NotificationMessage notificationMessage) {
+        super.onNotifyMessageUnShow(context, notificationMessage);
         new Handler(Looper.getMainLooper()).post(new Runnable() {
             @Override
             public void run() {
-                JPushHelper.getInstance().onNotifyMessageUnShow(notificationMessage);
+                if (JPushHelper.getInstance().getChannel() != null) {
+                    JPushHelper.getInstance().onNotifyMessageUnShow(notificationMessage);
+                }
             }
         });
     }
+
     @Override
-    public void onConnected(Context context,final boolean isConnected) {
+    public void onConnected(Context context, final boolean isConnected) {
         //连接状态
         new Handler(Looper.getMainLooper()).post(new Runnable() {
             @Override
             public void run() {
-                JPushHelper.getInstance().onConnected(isConnected);
+                if (JPushHelper.getInstance().getChannel() != null) {
+                    JPushHelper.getInstance().onConnected(isConnected);
+                }
             }
         });
     }
 
     @Override
-    public void onInAppMessageShow(Context context,final NotificationMessage message) {
+    public void onInAppMessageShow(Context context, final NotificationMessage message) {
         Log.i("JPushPlugin", "[onInAppMessageShow], " + message.toString());
         new Handler(Looper.getMainLooper()).post(new Runnable() {
             @Override
             public void run() {
-                JPushHelper.getInstance().onInAppMessageShow(message);
+                if (JPushHelper.getInstance().getChannel() != null) {
+                    JPushHelper.getInstance().onInAppMessageShow(message);
+                }
             }
         });
     }
 
     @Override
-    public void onInAppMessageClick(Context context,final NotificationMessage message) {
+    public void onInAppMessageClick(Context context, final NotificationMessage message) {
         Log.i("JPushPlugin", "[onInAppMessageClick], " + message.toString());
         new Handler(Looper.getMainLooper()).post(new Runnable() {
             @Override
             public void run() {
-                JPushHelper.getInstance().onInAppMessageClick(message);
+                if (JPushHelper.getInstance().getChannel() != null) {
+                    JPushHelper.getInstance().onInAppMessageClick(message);
+                }
             }
         });
     }
+
     @Override
     public void onTagOperatorResult(Context context, final JPushMessage jPushMessage) {
         super.onTagOperatorResult(context, jPushMessage);
@@ -109,17 +119,16 @@ public class JPushEventReceiver extends JPushMessageService {
     }
 
 
-
     @Override
     public void onCheckTagOperatorResult(Context context, final JPushMessage jPushMessage) {
         super.onCheckTagOperatorResult(context, jPushMessage);
 
 
-
         final int sequence = jPushMessage.getSequence();
 
 
-        final Result callback = JPushHelper.getInstance().getCallback(sequence);;
+        final Result callback = JPushHelper.getInstance().getCallback(sequence);
+        ;
 
         if (callback == null) {
             Log.i("JPushPlugin", "Unexpected error, callback is null!");
@@ -152,7 +161,8 @@ public class JPushEventReceiver extends JPushMessageService {
         final int sequence = jPushMessage.getSequence();
 
 
-        final Result callback = JPushHelper.getInstance().getCallback(sequence);;
+        final Result callback = JPushHelper.getInstance().getCallback(sequence);
+        ;
 
         if (callback == null) {
             Log.i("JPushPlugin", "Unexpected error, callback is null!");
@@ -164,7 +174,7 @@ public class JPushEventReceiver extends JPushMessageService {
             public void run() {
                 if (jPushMessage.getErrorCode() == 0) { // success
                     Map<String, Object> res = new HashMap<>();
-                    res.put("alias", (jPushMessage.getAlias() == null)? "" : jPushMessage.getAlias());
+                    res.put("alias", (jPushMessage.getAlias() == null) ? "" : jPushMessage.getAlias());
                     callback.success(res);
 
                 } else {
@@ -182,7 +192,7 @@ public class JPushEventReceiver extends JPushMessageService {
 
 
         HashMap<String, Object> map = new HashMap();
-        map.put("isEnabled",isOn);
-        JPushHelper.getInstance().runMainThread(map,null,"onReceiveNotificationAuthorization");
+        map.put("isEnabled", isOn);
+        JPushHelper.getInstance().runMainThread(map, null, "onReceiveNotificationAuthorization");
     }
 }


### PR DESCRIPTION
java.lang.NullPointerException

Attempt to invoke virtual method 'void io.flutter.plugin.common.MethodChannel.invokeMethod(java.lang.String, java.lang.Object)' on a null object reference