### PR TITLE
修复 pub.dev dry-run 发布包过滤

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -142,10 +142,8 @@ fastlane/readme.md
 pubspec.lock
 example/.flutter-plugins-dependencies
 example/pubspec.lock
-example/ios/Flutter/flutter_export_environment.sh
 .dart_tool/
 # Claude update-sdk skill temp files
 .claude/skills/update-sdk/scripts/.sdk_download_result.json
-.claude/skills/update-sdk/scripts/.changelog_cache.json
 .claude/settings.local.json
 docs/

--- a/.pubignore
+++ b/.pubignore
@@ -1,6 +1,14 @@
 # 排除示例项目
 example/
 
+# 排除本地分析和调试文档
+docs/
+
+# 排除已跟踪但不应发布的本地/生成文件
+.claude/skills/update-sdk/scripts/.changelog_cache.json
+example/ios/Flutter/flutter_export_environment.sh
+example/ios/Runner/GeneratedPluginRegistrant.m
+
 # 排除构建文件
 build/
 .dart_tool/

--- a/example/ios/.gitignore
+++ b/example/ios/.gitignore
@@ -10,7 +10,6 @@ profile
 DerivedData/
 build/
 GeneratedPluginRegistrant.h
-GeneratedPluginRegistrant.m
 
 .generated/
 


### PR DESCRIPTION
## 变更说明
- 通过 .pubignore 排除本地 docs、Claude 缓存和 iOS 生成文件。
- 调整 .gitignore / example/ios/.gitignore，避免已跟踪文件同时被 gitignore 忽略导致 pub.dev dry-run warning。

## 验证
- git diff --check 通过。
- flutter pub publish --dry-run 通过，0 warnings。