### PR TITLE
feat: 升级 JPush 6.2.0 并支持小米订阅消息

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 3.4.8 (2026-07-27)
+
+- Android 与 iOS JPush SDK 升级至 6.2.0，JCore SDK 升级至 5.5.0。
+- 新增 Android 小米订阅消息接口 `requestSubscribeChannel`，订阅结果通过 `onCommandResult` 回调。
+
 ## 3.4.7 (2026-07-09)
 
 适配 Flutter 3.35 / Dart 3，放宽 Dart SDK 约束到 `>=2.19.6 <4.0.0`。

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ dependencies:
       
 // pub 集成
 dependencies:
-  jpush_flutter: 3.4.6
+  jpush_flutter: 3.4.8
 ```
 
 ### 配置
@@ -61,4 +61,3 @@ final JPushFlutterInterface jpush = JPush.newJPush();
 **注意** : 需要先调用 JPush.setup 来初始化插件，才能保证其他功能正常工作。
 
  [参考](./documents/APIs.md)
-

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -38,5 +38,5 @@ android {
 }
 
 dependencies {
-    implementation ('cn.jiguang.sdk:jpush:6.1.0')
+    implementation ('cn.jiguang.sdk:jpush:6.2.0')
 }

--- a/android/src/main/java/com/jiguang/jpush/JPushPlugin.java
+++ b/android/src/main/java/com/jiguang/jpush/JPushPlugin.java
@@ -250,6 +250,8 @@ public class JPushPlugin implements FlutterPlugin, MethodCallHandler, ActivityAw
             setChannelAndSound(call, result);
         }else if (call.method.equals("requestRequiredPermission")) {
             requestRequiredPermission(call, result);
+        }else if (call.method.equals("requestSubscribeChannel")) {
+            requestSubscribeChannel(call, result);
         }else if (call.method.equals("setThirdToken")) {
             setThirdToken(call, result);
         }else if (call.method.equals("setDataInsightsEnable")) {
@@ -267,6 +269,33 @@ public class JPushPlugin implements FlutterPlugin, MethodCallHandler, ActivityAw
     public void requestRequiredPermission(MethodCall call, Result result){
         JPushInterface.requestRequiredPermission(mActivity);
 
+        result.success(true);
+    }
+    public void requestSubscribeChannel(MethodCall call, Result result) {
+        HashMap<String, Object> arguments = call.arguments();
+        Object channelIdsObject = arguments == null ? null : arguments.get("channelIds");
+        if (!(channelIdsObject instanceof List)) {
+            result.error("INVALID_ARGUMENT", "channelIds must be a list", null);
+            return;
+        }
+
+        List<?> rawChannelIds = (List<?>) channelIdsObject;
+        if (rawChannelIds.isEmpty() || rawChannelIds.size() > 3) {
+            result.error("INVALID_ARGUMENT", "channelIds must contain between 1 and 3 items", null);
+            return;
+        }
+
+        ArrayList<String> channelIds = new ArrayList<>();
+        for (Object channelIdObject : rawChannelIds) {
+            if (!(channelIdObject instanceof String)
+                    || TextUtils.isEmpty(((String) channelIdObject).trim())) {
+                result.error("INVALID_ARGUMENT", "channelIds items must be non-empty strings", null);
+                return;
+            }
+            channelIds.add((String) channelIdObject);
+        }
+
+        JPushInterface.requestSubscribeChannel(context, channelIds);
         result.success(true);
     }
     public void setHBInterval(MethodCall call, Result result){

--- a/documents/APIs.md
+++ b/documents/APIs.md
@@ -8,6 +8,7 @@
 - [getPushStatus](#getpushstatus)
 - [setLatestNotificationNumber](#setlatestnotificationnumber)
 - [requestRequiredPermission](#requestrequiredpermission)
+- [requestSubscribeChannel](#requestsubscribechannel)
 - [setAlias](#setalias)
 - [getAlias](#getAlias)
 - [deleteAlias](#deletealias)
@@ -360,6 +361,34 @@ JPushFlutterInterface jpush = JPush.newJPush();
 jpush.requestRequiredPermission();
 ```
 
+#### requestSubscribeChannel
+
+请求订阅小米消息渠道，并拉起小米订阅授权弹窗。
+
+**Android Only**
+
+开始支持的版本：JPush Android SDK 6.2.0。仅在已集成并注册小米通道的小米设备上会拉起弹窗并产生回调；其它厂商或设备调用后不会触发回调。
+
+```dart
+JPushFlutterInterface jpush = JPush.newJPush();
+jpush.requestSubscribeChannel(['your_channel_id']);
+```
+
+##### 参数说明
+
+- `channelIds` (`List<String>`)：小米后台申请的订阅类 channelId，每次必须传入 1～3 个非空值。
+
+##### 回调说明
+
+结果通过 `addEventHandler` 的 `onCommandResult` 回调：
+
+- `cmd`：固定为 `2012`
+- `errorCode`：小米整体结果码，`0` 表示用户操作结果正常返回
+- `extras.open_channel_result`：各 channel 操作结果 JSON 字符串
+- `extras.jg_platform`：厂商标识，小米为 `1`
+
+小米侧限制订阅弹窗 30 秒内最多调用一次，单 channel 一个月内最多调用两次；频控时 `errorCode` 为 `-500`。
+
 #### getPushStatus
 
 获取推送状态。
@@ -557,4 +586,3 @@ jpush.pageEnterTo("页面名");
 JPushFlutterInterface jpush = JPush.newJPush();
 jpush.pageLeave("页面名");
 ```
-

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -196,6 +196,18 @@ class _MyAppState extends State<MyApp> {
               children: <Widget>[
                 new Text(" "),
                 new CustomButton(
+                    title: "requestSubscribeChannel",
+                    onPressed: () {
+                      if (Platform.isAndroid) {
+                        jpush.requestSubscribeChannel(["your_channel_id"]);
+                      }
+                    }),
+              ]),
+          new Row(
+              mainAxisAlignment: MainAxisAlignment.center,
+              children: <Widget>[
+                new Text(" "),
+                new CustomButton(
                     title: "setTags",
                     onPressed: () {
                       jpush.setTags(["lala", "haha"]).then((map) {

--- a/ios/jpush_flutter.podspec
+++ b/ios/jpush_flutter.podspec
@@ -15,8 +15,8 @@ A new flutter plugin project.
   s.source_files = 'Classes/**/*'
   s.public_header_files = 'Classes/**/*.h'
   s.dependency 'Flutter'
-  s.dependency 'JCore','>= 5.2.0'
-  s.dependency 'JPush','6.1.0'
+  s.dependency 'JCore','>= 5.5.0'
+  s.dependency 'JPush','6.2.0'
   
   s.ios.deployment_target = '8.0'
   s.static_framework = true

--- a/lib/android_ios/jpush_flutter_a_i.dart
+++ b/lib/android_ios/jpush_flutter_a_i.dart
@@ -580,6 +580,24 @@ class JPush_A_I extends JPushFlutterInterface {
     _channel.invokeMethod('requestRequiredPermission');
   }
 
+  /// Android Only
+  /// 请求订阅小米消息渠道。结果通过 addEventHandler 的 onCommandResult 回调。
+  void requestSubscribeChannel(List<String> channelIds) {
+    if (!Platform.isAndroid) {
+      return;
+    }
+    if (channelIds.isEmpty || channelIds.length > 3) {
+      throw ArgumentError.value(
+          channelIds, 'channelIds', 'must contain between 1 and 3 items');
+    }
+    if (channelIds.any((channelId) => channelId.trim().isEmpty)) {
+      throw ArgumentError.value(
+          channelIds, 'channelIds', 'items must not be empty');
+    }
+    _channel.invokeMethod(
+        'requestSubscribeChannel', {'channelIds': channelIds});
+  }
+
   /// 设置退后台时是否维持极光长连接。
   /// iOS 默认 false（不维持），Android 默认 true（维持）。
   void setBackgroundEnable({bool enable = false}) {

--- a/lib/jpush_interface.dart
+++ b/lib/jpush_interface.dart
@@ -363,6 +363,12 @@ abstract class JPushFlutterInterface {
     print(flutter_log + "requestRequiredPermission:has not been implemented.");
   }
 
+  /// Android Only
+  /// 请求订阅小米消息渠道。结果通过 addEventHandler 的 onCommandResult 回调。
+  void requestSubscribeChannel(List<String> channelIds) {
+    print(flutter_log + "requestSubscribeChannel:has not been implemented.");
+  }
+
   /// 设置退后台时是否维持极光长连接。
   /// iOS 默认 false（不维持），Android 默认 true（维持）。
   void setBackgroundEnable({bool enable = false}) {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: jpush_flutter
 description: JIGUANG officially supported JPush Flutter plugin (Android, iOS & HarmonyOS). 极光推送官方支持的 Flutter 插件（Android、iOS 与鸿蒙）(https://www.jiguang.cn).
-version: 3.4.7
+version: 3.4.8
 # author: xudong.rao <xudong.rao@outlook.com>
 homepage: https://www.jiguang.cn
 


### PR DESCRIPTION
## 变更说明

- Android 与 iOS JPush SDK 升级至 6.2.0
- Android JCore 解析至 5.5.0，iOS JCore 约束调整为 `>= 5.5.0`
- 新增 Android 小米订阅消息接口 `requestSubscribeChannel`
- 补充参数校验、示例入口、API 文档和 CHANGELOG

## 验证结果

- `flutter pub get` 通过
- example `flutter pub get` 通过
- `flutter analyze` 通过
- `git diff --check` 通过
- Android 依赖解析及 debug APK 构建通过
- iOS Pod 依赖解析及无签名构建通过
- 小米 Android 16 真机验证通过：无通知权限返回 `-800`；授权后成功拉起订阅弹窗，允许 channelID `155012` 后返回 `cmd=2012`、`errorCode=0`、channel `code=100`

## 未覆盖项

- 用户拒绝分支
- 30 秒及单 channel 月度频控
- 实际订阅消息下发