### PR TITLE
feat: 增加 iOS Live Activity Token 接口

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - iOS JPush SDK 升级至 6.2.2，JCore SDK 最低版本升级至 5.5.1。
 - iOS 支持 `turnOffPush` / `turnOnPush`，用于反注册和恢复推送服务。
+- iOS 支持 Live Activity PushToken 与 Push-to-Start Token 的注册、更新和解绑。
 
 ## 3.5.3 (2026-08-20)
 

--- a/documents/APIs.md
+++ b/documents/APIs.md
@@ -36,6 +36,8 @@
 - [pageEnterTo](#pageEnterTo)
 - [pageLeave](#pageLeave)
 - [setBackgroundEnable](#setbackgroundenable)
+- [registerLiveActivityPushToken](#registerliveactivitypushtoken)
+- [registerLiveActivityPushToStartToken](#registerliveactivitypushtostarttoken)
 
 
 [harmony Only]()
@@ -489,6 +491,67 @@ jpush.turnOnPush();
 - iOS 不会自动枚举 ActivityKit 活动或恢复 Live Activity Token，业务应在登录成功后主动重新获取并上报
 - HarmonyOS 会重新获取 Token、建立长连接，RegistrationID 保持不变
 - 快速交错调用时，最终状态以最后一次 `turnOnPush` / `turnOffPush` 为准
+
+#### registerLiveActivityPushToken
+
+注册或更新指定 Live Activity 的 PushToken；传 `null` 表示解绑。仅支持 iOS，原生 JPush SDK 需为 4.9.0 或更高版本。
+
+```dart
+import 'dart:typed_data';
+
+final Uint8List token = activityPushToken;
+final result = await jpush.registerLiveActivityPushToken(
+  liveActivityId: 'order-123',
+  pushToken: token,
+  seq: 1,
+);
+
+// Live Activity 结束或停用 JPush 前，使用绑定时相同的 liveActivityId 解绑。
+final unbindResult = await jpush.registerLiveActivityPushToken(
+  liveActivityId: 'order-123',
+  pushToken: null,
+  seq: 2,
+);
+```
+
+参数说明：
+
+- `liveActivityId`：业务定义的活动标识，解绑时必须与注册时保持一致；最多 64 字节
+- `pushToken`：ActivityKit 提供的 Token；传 `null` 表示解绑
+- `seq`：请求序列号，回调时原样返回
+
+#### registerLiveActivityPushToStartToken
+
+注册或更新某种 `ActivityAttributes` 对应的 Push-to-Start Token；传 `null` 表示解绑。仅支持 iOS，原生 JPush SDK 需为 5.5.0 或更高版本，Token 获取需要 iOS 17.2 及相应版本的 Xcode SDK。
+
+```dart
+final result = await jpush.registerLiveActivityPushToStartToken(
+  activityAttributes: 'OrderActivityAttributes',
+  pushToStartToken: pushToStartToken,
+  seq: 3,
+);
+
+final unbindResult = await jpush.registerLiveActivityPushToStartToken(
+  activityAttributes: 'OrderActivityAttributes',
+  pushToStartToken: null,
+  seq: 4,
+);
+```
+
+参数说明：
+
+- `activityAttributes`：业务中 `ActivityAttributes` 类型的标识；存在多种类型时需分别注册和解绑
+- `pushToStartToken`：ActivityKit 提供的启动 Token；传 `null` 表示解绑
+- `seq`：请求序列号，回调时原样返回
+
+两个接口均返回 Map：
+
+- `code` (`int`)：`0` 表示成功，其它值为原生 SDK 错误码
+- `liveActivityId` (`String`)：原生回调返回的活动或属性类型标识
+- `pushToken` (`Uint8List?`)：原生回调返回的 Token；解绑时可能为 `null`
+- `seq` (`int`)：调用时传入的请求序列号
+
+插件只负责向 JPush 上报或解绑 Token，不负责创建 Live Activity、枚举活动或监听 ActivityKit Token 更新。调用 `turnOffPush` 前应先解绑两类 Token；调用 `turnOnPush` 并收到登录成功通知后，应由业务重新获取并上报当前 Token。
 
 #### setAlias
 

--- a/example/README.md
+++ b/example/README.md
@@ -6,3 +6,22 @@ Demonstrates how to use the jpush plugin.
 
 For help getting started with Flutter, view our online
 [documentation](https://flutter.io/).
+
+## iOS Live Activity Token 测试
+
+Demo 页面包含 Live Activity PushToken 与 Push-to-Start Token 的注册和解绑测试面板，仅在 iOS 显示。
+
+1. 使用 ActivityKit 获取真实 Token。测试面板同时接受 Base64 和十六进制格式；如需转换可使用：
+
+   ```swift
+   let tokenBase64 = token.base64EncodedString()
+   let tokenHex = token.map { String(format: "%02x", $0) }.joined()
+   ```
+
+2. 将 Token 粘贴到对应输入框。可选使用 `base64:`、`hex:` 或 `0x` 前缀明确格式：
+   - 普通 Live Activity 使用相同的 `Live Activity ID` 注册、更新和解绑；
+   - Push-to-Start 使用相同的 `ActivityAttributes` 标识注册、更新和解绑。
+3. 点击注册按钮，确认页面顶部结果中的 `code` 为 `0`，并检查 `seq` 和 `tokenLength`。
+4. 点击对应解绑按钮。解绑时 Token 输入框可以留空，Demo 会向插件传入 `null`。
+
+PushToken 测试需要 iOS 16.1+；Push-to-Start Token 测试需要 iOS 17.2+。Demo 仅负责调用 JPush Flutter 接口，不创建 Live Activity，也不监听 ActivityKit Token 更新。

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -1,8 +1,8 @@
+import 'dart:async';
+import 'dart:convert';
 import 'dart:io';
 
 import 'package:flutter/material.dart';
-import 'dart:async';
-
 import 'package:flutter/services.dart';
 import 'package:jpush_flutter/jpush_flutter.dart';
 import 'package:jpush_flutter/jpush_interface.dart';
@@ -141,8 +141,9 @@ class _MyAppState extends State<MyApp> {
         appBar: new AppBar(
           title: const Text('Plugin example app'),
         ),
-        body: new Center(
-            child: new Column(children: [
+        body: new SingleChildScrollView(
+            child: new Center(
+                child: new Column(children: [
           Container(
             margin: EdgeInsets.fromLTRB(10, 10, 10, 10),
             color: Colors.brown,
@@ -387,6 +388,14 @@ class _MyAppState extends State<MyApp> {
                   }),
             ],
           ),
+          LiveActivityTestPanel(
+            jpush: jpush,
+            onResult: (message) {
+              setState(() {
+                debugLable = message;
+              });
+            },
+          ),
           new Row(
             mainAxisAlignment: MainAxisAlignment.center,
             children: <Widget>[
@@ -479,7 +488,270 @@ class _MyAppState extends State<MyApp> {
                   }),
             ],
           ),
-        ])),
+        ]))),
+      ),
+    );
+  }
+}
+
+/// iOS Live Activity Token 注册与解绑测试面板。
+class LiveActivityTestPanel extends StatefulWidget {
+  final JPushFlutterInterface jpush;
+  final ValueChanged<String> onResult;
+  final bool? isIOS;
+
+  const LiveActivityTestPanel({
+    required this.jpush,
+    required this.onResult,
+    this.isIOS,
+  });
+
+  @override
+  State<LiveActivityTestPanel> createState() => _LiveActivityTestPanelState();
+}
+
+class _LiveActivityTestPanelState extends State<LiveActivityTestPanel> {
+  final TextEditingController _liveActivityIdController =
+      TextEditingController(text: 'jpush_flutter_live_activity_demo');
+  final TextEditingController _activityAttributesController =
+      TextEditingController(text: 'OrderActivityAttributes');
+  final TextEditingController _pushTokenController = TextEditingController();
+  final TextEditingController _pushToStartTokenController =
+      TextEditingController();
+  int _seq = 1000;
+  bool _isSubmitting = false;
+  String _resultText = '等待操作';
+
+  @override
+  void dispose() {
+    _liveActivityIdController.dispose();
+    _activityAttributesController.dispose();
+    _pushTokenController.dispose();
+    _pushToStartTokenController.dispose();
+    super.dispose();
+  }
+
+  Uint8List _parseToken(String input) {
+    var normalized = input.replaceAll(RegExp(r'\s'), '');
+    if (normalized.isEmpty) {
+      throw const FormatException('请先粘贴 ActivityKit Token');
+    }
+
+    final lowerCase = normalized.toLowerCase();
+    final hasHexPrefix =
+        lowerCase.startsWith('hex:') || lowerCase.startsWith('0x');
+    final hasBase64Prefix = lowerCase.startsWith('base64:');
+    if (hasHexPrefix) {
+      normalized = normalized.substring(lowerCase.startsWith('hex:') ? 4 : 2);
+      return _decodeHexToken(normalized);
+    }
+    if (hasBase64Prefix) {
+      normalized = normalized.substring(7);
+      return _decodeBase64Token(normalized);
+    }
+
+    final hexWithoutSeparators = normalized.replaceAll(':', '');
+    if (hexWithoutSeparators.length.isEven &&
+        RegExp(r'^[0-9a-fA-F]+$').hasMatch(hexWithoutSeparators)) {
+      return _decodeHexToken(hexWithoutSeparators);
+    }
+    return _decodeBase64Token(normalized);
+  }
+
+  Uint8List _decodeHexToken(String input) {
+    final normalized = input.replaceAll(':', '');
+    if (normalized.isEmpty ||
+        normalized.length.isOdd ||
+        !RegExp(r'^[0-9a-fA-F]+$').hasMatch(normalized)) {
+      throw const FormatException('hex Token 必须是偶数位十六进制字符串');
+    }
+    return Uint8List.fromList(<int>[
+      for (var index = 0; index < normalized.length; index += 2)
+        int.parse(normalized.substring(index, index + 2), radix: 16),
+    ]);
+  }
+
+  Uint8List _decodeBase64Token(String input) {
+    try {
+      final token = base64.decode(base64.normalize(input));
+      if (token.isEmpty) {
+        throw const FormatException('Base64 Token 不能为空');
+      }
+      return token;
+    } on FormatException {
+      throw const FormatException('Token 必须是有效的 hex 或 Base64 字符串');
+    }
+  }
+
+  String _formatResult(String action, Map<dynamic, dynamic> result) {
+    final token = result['pushToken'];
+    final tokenLength = token is Uint8List ? token.length : 0;
+    return '$action: code=${result['code']}, '
+        'liveActivityId=${result['liveActivityId']}, '
+        'seq=${result['seq']}, tokenLength=$tokenLength';
+  }
+
+  void _report(String message) {
+    if (mounted) {
+      setState(() {
+        _resultText = message;
+      });
+      widget.onResult(message);
+    }
+  }
+
+  Future<void> _registerPushToken({required bool unbind}) async {
+    if (_isSubmitting) return;
+    setState(() {
+      _isSubmitting = true;
+      _resultText = unbind ? '正在解绑 PushToken…' : '正在注册 PushToken…';
+    });
+    try {
+      final liveActivityId = _liveActivityIdController.text.trim();
+      if (liveActivityId.isEmpty || utf8.encode(liveActivityId).length > 64) {
+        throw const FormatException('Live Activity ID 必须为 1～64 字节');
+      }
+      final result = await widget.jpush.registerLiveActivityPushToken(
+        liveActivityId: liveActivityId,
+        pushToken: unbind ? null : _parseToken(_pushTokenController.text),
+        seq: _seq++,
+      );
+      _report(_formatResult(
+        unbind ? '解绑 Live Activity PushToken' : '注册 Live Activity PushToken',
+        result,
+      ));
+    } catch (error) {
+      _report('Live Activity PushToken 测试失败: $error');
+    } finally {
+      if (mounted) {
+        setState(() {
+          _isSubmitting = false;
+        });
+      }
+    }
+  }
+
+  Future<void> _registerPushToStartToken({required bool unbind}) async {
+    if (_isSubmitting) return;
+    setState(() {
+      _isSubmitting = true;
+      _resultText =
+          unbind ? '正在解绑 Push-to-Start Token…' : '正在注册 Push-to-Start Token…';
+    });
+    try {
+      final activityAttributes = _activityAttributesController.text.trim();
+      if (activityAttributes.isEmpty) {
+        throw const FormatException('ActivityAttributes 标识不能为空');
+      }
+      final result = await widget.jpush.registerLiveActivityPushToStartToken(
+        activityAttributes: activityAttributes,
+        pushToStartToken:
+            unbind ? null : _parseToken(_pushToStartTokenController.text),
+        seq: _seq++,
+      );
+      _report(_formatResult(
+        unbind
+            ? '解绑 Live Activity Push-to-Start Token'
+            : '注册 Live Activity Push-to-Start Token',
+        result,
+      ));
+    } catch (error) {
+      _report('Live Activity Push-to-Start Token 测试失败: $error');
+    } finally {
+      if (mounted) {
+        setState(() {
+          _isSubmitting = false;
+        });
+      }
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (!(widget.isIOS ?? Platform.isIOS)) {
+      return const SizedBox.shrink();
+    }
+    return Container(
+      width: 350,
+      margin: const EdgeInsets.all(10),
+      padding: const EdgeInsets.all(10),
+      decoration: BoxDecoration(
+        border: Border.all(color: Colors.grey),
+        borderRadius: BorderRadius.circular(6),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: <Widget>[
+          const Text(
+            'iOS Live Activity Token 测试',
+            style: TextStyle(fontWeight: FontWeight.bold),
+          ),
+          const Text('支持 Base64 或 hex Token；解绑无需填写 Token。'),
+          if (_isSubmitting) const LinearProgressIndicator(),
+          Text(
+            _resultText,
+            style: const TextStyle(color: Colors.blueGrey),
+          ),
+          TextField(
+            controller: _liveActivityIdController,
+            decoration: const InputDecoration(labelText: 'Live Activity ID'),
+          ),
+          TextField(
+            key: const ValueKey<String>('liveActivityPushTokenInput'),
+            controller: _pushTokenController,
+            autocorrect: false,
+            decoration:
+                const InputDecoration(labelText: 'PushToken（Base64 / hex）'),
+          ),
+          Wrap(
+            alignment: WrapAlignment.center,
+            spacing: 8,
+            children: <Widget>[
+              CustomButton(
+                title: '注册 PushToken',
+                onPressed: _isSubmitting
+                    ? null
+                    : () => _registerPushToken(unbind: false),
+              ),
+              CustomButton(
+                title: '解绑 PushToken',
+                onPressed: _isSubmitting
+                    ? null
+                    : () => _registerPushToken(unbind: true),
+              ),
+            ],
+          ),
+          TextField(
+            controller: _activityAttributesController,
+            decoration:
+                const InputDecoration(labelText: 'ActivityAttributes 标识'),
+          ),
+          TextField(
+            key: const ValueKey<String>('liveActivityPushToStartTokenInput'),
+            controller: _pushToStartTokenController,
+            autocorrect: false,
+            decoration: const InputDecoration(
+                labelText: 'Push-to-Start Token（Base64 / hex）'),
+          ),
+          Wrap(
+            alignment: WrapAlignment.center,
+            spacing: 8,
+            children: <Widget>[
+              CustomButton(
+                title: '注册 Push-to-Start',
+                onPressed: _isSubmitting
+                    ? null
+                    : () => _registerPushToStartToken(unbind: false),
+              ),
+              CustomButton(
+                title: '解绑 Push-to-Start',
+                onPressed: _isSubmitting
+                    ? null
+                    : () => _registerPushToStartToken(unbind: true),
+              ),
+            ],
+          ),
+        ],
       ),
     );
   }

--- a/ios/jpush_flutter/Sources/jpush_flutter/JPushPlugin.m
+++ b/ios/jpush_flutter/Sources/jpush_flutter/JPushPlugin.m
@@ -36,6 +36,31 @@
 
 static NSMutableArray<FlutterResult>* getRidResults;
 
+static NSData *JPushLiveActivityTokenData(id value) {
+    if ([value isKindOfClass:[FlutterStandardTypedData class]]) {
+        return [(FlutterStandardTypedData *)value data];
+    }
+    if ([value isKindOfClass:[NSData class]]) {
+        return value;
+    }
+    return nil;
+}
+
+static NSDictionary *JPushLiveActivityTokenResult(NSInteger code,
+                                                   NSString *liveActivityId,
+                                                   NSData *pushToken,
+                                                   NSInteger seq) {
+    id token = pushToken
+        ? [FlutterStandardTypedData typedDataWithBytes:pushToken]
+        : [NSNull null];
+    return @{
+        @"code": @(code),
+        @"liveActivityId": liveActivityId ?: @"",
+        @"pushToken": token,
+        @"seq": @(seq)
+    };
+}
+
 @implementation JPushPlugin {
     NSDictionary *_launchNotification;
     NSDictionary *_completeLaunchNotification;
@@ -163,6 +188,10 @@ static NSMutableArray<FlutterResult>* getRidResults;
         [self turnOffPush:call result:result];
     } else if([@"turnOnPush" isEqualToString:call.method]) {
         [self turnOnPush:call result:result];
+    } else if([@"registerLiveActivityPushToken" isEqualToString:call.method]) {
+        [self registerLiveActivityPushToken:call result:result];
+    } else if([@"registerLiveActivityPushToStartToken" isEqualToString:call.method]) {
+        [self registerLiveActivityPushToStartToken:call result:result];
     } else if([@"clearAllNotifications" isEqualToString:call.method]) {
         [self clearAllNotifications:call result:result];
     } else if ([@"clearNotification" isEqualToString:call.method]) {
@@ -284,6 +313,56 @@ static NSMutableArray<FlutterResult>* getRidResults;
     JPLog(@"turnOnPush:");
     [JPUSHService turnOnPush];
     result(@(YES));
+}
+
+- (void)registerLiveActivityPushToken:(FlutterMethodCall*)call result:(FlutterResult)result {
+    NSDictionary *arguments = call.arguments;
+    NSString *liveActivityId = arguments[@"liveActivityId"];
+    id tokenArgument = arguments[@"pushToken"];
+    NSNumber *seq = arguments[@"seq"];
+    if (![liveActivityId isKindOfClass:[NSString class]] ||
+        ![seq isKindOfClass:[NSNumber class]] ||
+        (tokenArgument != nil && tokenArgument != [NSNull null] &&
+         ![tokenArgument isKindOfClass:[FlutterStandardTypedData class]] &&
+         ![tokenArgument isKindOfClass:[NSData class]])) {
+        result([FlutterError errorWithCode:@"invalid_arguments"
+                                   message:@"Invalid Live Activity PushToken arguments"
+                                   details:nil]);
+        return;
+    }
+
+    JPLog(@"registerLiveActivityPushToken");
+    [JPUSHService registerLiveActivity:liveActivityId
+                             pushToken:JPushLiveActivityTokenData(tokenArgument)
+                            completion:^(NSInteger code, NSString *activityId, NSData *token, NSInteger callbackSeq) {
+        result(JPushLiveActivityTokenResult(code, activityId, token, callbackSeq));
+    }
+                                   seq:[seq integerValue]];
+}
+
+- (void)registerLiveActivityPushToStartToken:(FlutterMethodCall*)call result:(FlutterResult)result {
+    NSDictionary *arguments = call.arguments;
+    NSString *activityAttributes = arguments[@"activityAttributes"];
+    id tokenArgument = arguments[@"pushToStartToken"];
+    NSNumber *seq = arguments[@"seq"];
+    if (![activityAttributes isKindOfClass:[NSString class]] ||
+        ![seq isKindOfClass:[NSNumber class]] ||
+        (tokenArgument != nil && tokenArgument != [NSNull null] &&
+         ![tokenArgument isKindOfClass:[FlutterStandardTypedData class]] &&
+         ![tokenArgument isKindOfClass:[NSData class]])) {
+        result([FlutterError errorWithCode:@"invalid_arguments"
+                                   message:@"Invalid Live Activity Push-to-Start Token arguments"
+                                   details:nil]);
+        return;
+    }
+
+    JPLog(@"registerLiveActivityPushToStartToken");
+    [JPUSHService registerLiveActivity:activityAttributes
+                      pushToStartToken:JPushLiveActivityTokenData(tokenArgument)
+                            completion:^(NSInteger code, NSString *activityId, NSData *token, NSInteger callbackSeq) {
+        result(JPushLiveActivityTokenResult(code, activityId, token, callbackSeq));
+    }
+                                   seq:[seq integerValue]];
 }
 
 - (void)setup:(FlutterMethodCall*)call result:(FlutterResult)result {

--- a/lib/android_ios/jpush_flutter_a_i.dart
+++ b/lib/android_ios/jpush_flutter_a_i.dart
@@ -493,6 +493,58 @@ class JPush_A_I extends JPushFlutterInterface {
     _channel.invokeMethod('turnOnPush');
   }
 
+  @override
+  Future<Map<dynamic, dynamic>> registerLiveActivityPushToken({
+    required String liveActivityId,
+    Uint8List? pushToken,
+    required int seq,
+  }) async {
+    if (!_isIOS) {
+      return super.registerLiveActivityPushToken(
+        liveActivityId: liveActivityId,
+        pushToken: pushToken,
+        seq: seq,
+      );
+    }
+    print(flutter_log + "registerLiveActivityPushToken:");
+
+    final Map<dynamic, dynamic> result = await _channel.invokeMethod(
+      'registerLiveActivityPushToken',
+      <String, dynamic>{
+        'liveActivityId': liveActivityId,
+        'pushToken': pushToken,
+        'seq': seq,
+      },
+    );
+    return result;
+  }
+
+  @override
+  Future<Map<dynamic, dynamic>> registerLiveActivityPushToStartToken({
+    required String activityAttributes,
+    Uint8List? pushToStartToken,
+    required int seq,
+  }) async {
+    if (!_isIOS) {
+      return super.registerLiveActivityPushToStartToken(
+        activityAttributes: activityAttributes,
+        pushToStartToken: pushToStartToken,
+        seq: seq,
+      );
+    }
+    print(flutter_log + "registerLiveActivityPushToStartToken:");
+
+    final Map<dynamic, dynamic> result = await _channel.invokeMethod(
+      'registerLiveActivityPushToStartToken',
+      <String, dynamic>{
+        'activityAttributes': activityAttributes,
+        'pushToStartToken': pushToStartToken,
+        'seq': seq,
+      },
+    );
+    return result;
+  }
+
   ///
   /// 检查推送是否已停止。
   /// Android Only

--- a/lib/jpush_interface.dart
+++ b/lib/jpush_interface.dart
@@ -298,6 +298,32 @@ abstract class JPushFlutterInterface {
     print(flutter_log + "turnOnPush:has not been implemented.");
   }
 
+  /// iOS Only
+  /// 注册或更新指定 Live Activity 的 PushToken，传 null 表示解绑。
+  /// 返回值包含 code、liveActivityId、pushToken 和 seq。
+  Future<Map<dynamic, dynamic>> registerLiveActivityPushToken({
+    required String liveActivityId,
+    Uint8List? pushToken,
+    required int seq,
+  }) async {
+    print(flutter_log +
+        "registerLiveActivityPushToken:has not been implemented.");
+    return {};
+  }
+
+  /// iOS Only
+  /// 注册或更新 ActivityAttributes 类型对应的 Push-to-Start Token，传 null 表示解绑。
+  /// 返回值包含 code、liveActivityId、pushToken 和 seq。
+  Future<Map<dynamic, dynamic>> registerLiveActivityPushToStartToken({
+    required String activityAttributes,
+    Uint8List? pushToStartToken,
+    required int seq,
+  }) async {
+    print(flutter_log +
+        "registerLiveActivityPushToStartToken:has not been implemented.");
+    return {};
+  }
+
   ///
   /// 检查推送是否已停止。
   /// Android Only

--- a/test/jpush_flutter_a_i_test.dart
+++ b/test/jpush_flutter_a_i_test.dart
@@ -1,6 +1,29 @@
 import 'package:flutter/services.dart';
+import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:jpush_flutter/android_ios/jpush_flutter_a_i.dart';
+import 'package:jpush_flutter/jpush_interface.dart';
+
+import '../example/lib/main.dart' as example;
+
+class LiveActivityDemoJPush extends JPushFlutterInterface {
+  Uint8List? pushToken;
+
+  @override
+  Future<Map<dynamic, dynamic>> registerLiveActivityPushToken({
+    required String liveActivityId,
+    Uint8List? pushToken,
+    required int seq,
+  }) async {
+    this.pushToken = pushToken;
+    return <String, dynamic>{
+      'code': 0,
+      'liveActivityId': liveActivityId,
+      'pushToken': pushToken,
+      'seq': seq,
+    };
+  }
+}
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
@@ -53,5 +76,144 @@ void main() {
     await Future<void>.delayed(Duration.zero);
 
     expect(calls, isEmpty);
+  });
+
+  test('iOS 注册 Live Activity PushToken 并透传回调', () async {
+    final token = Uint8List.fromList(<int>[1, 2, 3]);
+    messenger.setMockMethodCallHandler(channel, (call) async {
+      expect(call.method, 'registerLiveActivityPushToken');
+      expect(call.arguments, <String, dynamic>{
+        'liveActivityId': 'order-1',
+        'pushToken': token,
+        'seq': 10,
+      });
+      return <String, dynamic>{
+        'code': 0,
+        'liveActivityId': 'order-1',
+        'pushToken': token,
+        'seq': 10,
+      };
+    });
+    final jpush = JPush_A_I.private(channel, isIOS: true);
+
+    final result = await jpush.registerLiveActivityPushToken(
+      liveActivityId: 'order-1',
+      pushToken: token,
+      seq: 10,
+    );
+
+    expect(result['code'], 0);
+    expect(result['pushToken'], token);
+  });
+
+  test('iOS 传 null 解绑 Live Activity PushToken', () async {
+    messenger.setMockMethodCallHandler(channel, (call) async {
+      expect(call.method, 'registerLiveActivityPushToken');
+      expect(call.arguments['pushToken'], isNull);
+      return <String, dynamic>{
+        'code': 0,
+        'liveActivityId': 'order-1',
+        'pushToken': null,
+        'seq': 11,
+      };
+    });
+    final jpush = JPush_A_I.private(channel, isIOS: true);
+
+    final result = await jpush.registerLiveActivityPushToken(
+      liveActivityId: 'order-1',
+      pushToken: null,
+      seq: 11,
+    );
+
+    expect(result['code'], 0);
+    expect(result['pushToken'], isNull);
+  });
+
+  test('iOS 注册和解绑 Live Activity Push-to-Start Token', () async {
+    final calls = <MethodCall>[];
+    messenger.setMockMethodCallHandler(channel, (call) async {
+      calls.add(call);
+      return <String, dynamic>{
+        'code': 0,
+        'liveActivityId': call.arguments['activityAttributes'],
+        'pushToken': call.arguments['pushToStartToken'],
+        'seq': call.arguments['seq'],
+      };
+    });
+    final jpush = JPush_A_I.private(channel, isIOS: true);
+    final token = Uint8List.fromList(<int>[4, 5, 6]);
+
+    final registerResult = await jpush.registerLiveActivityPushToStartToken(
+      activityAttributes: 'OrderActivityAttributes',
+      pushToStartToken: token,
+      seq: 20,
+    );
+    final unbindResult = await jpush.registerLiveActivityPushToStartToken(
+      activityAttributes: 'OrderActivityAttributes',
+      pushToStartToken: null,
+      seq: 21,
+    );
+
+    expect(calls, hasLength(2));
+    expect(calls.first.method, 'registerLiveActivityPushToStartToken');
+    expect(calls.first.arguments['pushToStartToken'], token);
+    expect(calls.last.arguments['pushToStartToken'], isNull);
+    expect(registerResult['pushToken'], token);
+    expect(registerResult['seq'], 20);
+    expect(unbindResult['pushToken'], isNull);
+    expect(unbindResult['seq'], 21);
+  });
+
+  test('非 iOS Live Activity 接口保持未实现兜底', () async {
+    final calls = <MethodCall>[];
+    messenger.setMockMethodCallHandler(channel, (call) async {
+      calls.add(call);
+      return null;
+    });
+    final jpush = JPush_A_I.private(channel, isIOS: false);
+
+    expect(
+      await jpush.registerLiveActivityPushToken(
+        liveActivityId: 'order-1',
+        pushToken: null,
+        seq: 1,
+      ),
+      isEmpty,
+    );
+    expect(
+      await jpush.registerLiveActivityPushToStartToken(
+        activityAttributes: 'OrderActivityAttributes',
+        pushToStartToken: null,
+        seq: 2,
+      ),
+      isEmpty,
+    );
+    expect(calls, isEmpty);
+  });
+
+  testWidgets('Demo 支持 Base64 PushToken 并在面板内显示结果', (tester) async {
+    final demoJPush = LiveActivityDemoJPush();
+    await tester.pumpWidget(MaterialApp(
+      home: Scaffold(
+        body: SingleChildScrollView(
+          child: example.LiveActivityTestPanel(
+            jpush: demoJPush,
+            isIOS: true,
+            onResult: (_) {},
+          ),
+        ),
+      ),
+    ));
+
+    await tester.enterText(
+      find.byKey(const ValueKey<String>('liveActivityPushTokenInput')),
+      'base64:AQIDBA==',
+    );
+    await tester.tap(find.text('注册 PushToken'));
+    await tester.pump();
+
+    expect(demoJPush.pushToken, Uint8List.fromList(<int>[1, 2, 3, 4]));
+    expect(find.textContaining('code=0'), findsOneWidget);
+    expect(find.textContaining('tokenLength=4'), findsOneWidget);
   });
 }


### PR DESCRIPTION
## 变更说明

- 新增 Live Activity PushToken 注册、更新与解绑接口
- 新增 Push-to-Start Token 注册、更新与解绑接口
- 补齐 Dart → MethodChannel → Objective-C → JPush SDK 调用与回调链路
- Demo 支持 Base64/hex Token 输入并展示脱敏结果
- 更新 API 文档、CHANGELOG 和测试

## 验证

- `flutter analyze` 通过
- `flutter test` 8/8 通过
- `git diff --check` 通过
- iOS example 使用 JPush 6.2.2 / JCore 5.5.1 构建、安装通过
- 真机 PushToken 与 Push-to-Start Token 注册回调均为 `code=0`

## 待补充场景

- Token 更新、`null` 解绑及服务端推送到达的端到端验证