### PR TITLE
发布：升级 Flutter 插件至 3.5.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 3.5.6 (2026-08-28)
+
+- iOS JPush SDK 升级至 6.2.4，CocoaPods 与 Swift Package Manager 依赖保持一致。
+- 修复 iOS 前台通知在 `unShow` 开启时未调用系统 completion handler 的问题，并明确前台通知展示选项。
+
 ## 3.5.5 (2026-08-24)
 
 - iOS JPush SDK 升级至 6.2.3，JCore SDK 依赖调整为 `> 5.5.0`，支持宿主工程显式选择 5.5.1-noidfa。

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ dependencies:
       
 // pub 集成
 dependencies:
-  jpush_flutter: 3.5.5
+  jpush_flutter: 3.5.6
 ```
 
 ### 配置

--- a/ios/jpush_flutter.podspec
+++ b/ios/jpush_flutter.podspec
@@ -16,7 +16,7 @@ A new flutter plugin project.
   s.public_header_files = 'jpush_flutter/Sources/jpush_flutter/include/**/*.h'
   s.dependency 'Flutter'
   s.dependency 'JCore','> 5.5.0'
-  s.dependency 'JPush','6.2.3'
+  s.dependency 'JPush','6.2.4'
 
   s.ios.deployment_target = '8.0'
   s.static_framework = true

--- a/ios/jpush_flutter/Package.swift
+++ b/ios/jpush_flutter/Package.swift
@@ -14,7 +14,7 @@ let package = Package(
     dependencies: [
         .package(name: "FlutterFramework", path: "../FlutterFramework"),
         .package(url: "https://github.com/jpush/jcore-sdk.git", from: "5.5.1"),
-        .package(url: "https://github.com/jpush/jpush-sdk.git", exact: "6.2.3")
+        .package(url: "https://github.com/jpush/jpush-sdk.git", exact: "6.2.4")
     ],
     targets: [
         .target(

--- a/ios/jpush_flutter/Sources/jpush_flutter/JPushPlugin.m
+++ b/ios/jpush_flutter/Sources/jpush_flutter/JPushPlugin.m
@@ -925,7 +925,12 @@ static NSDictionary *JPushLiveActivityTokenResult(NSInteger code,
         }
         JPLog(@"iOS10 前台收到本地通知:userInfo：%@",userInfo);
     }
-    if (!self.unShow) completionHandler(notificationTypes);
+//    if (!self.unShow) completionHandler(notificationTypes);
+    if (self.unShow) {
+        completionHandler(UNNotificationPresentationOptionNone);
+    }else {
+        completionHandler(UNNotificationPresentationOptionBadge|UNNotificationPresentationOptionSound|UNNotificationPresentationOptionAlert); // 需要执行这个方法，选择是否提醒用户，有Badge、Sound、Alert三种类型可以设置
+    }
 }
 
 - (void)jpushNotificationCenter:(UNUserNotificationCenter *)center didReceiveNotificationResponse:(UNNotificationResponse *)response withCompletionHandler:(void (^)(void))completionHandler  API_AVAILABLE(ios(10.0)){

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: jpush_flutter
 description: JIGUANG officially supported JPush Flutter plugin (Android, iOS & HarmonyOS). 极光推送官方支持的 Flutter 插件（Android、iOS 与鸿蒙）(https://www.jiguang.cn).
-version: 3.5.5
+version: 3.5.6
 # author: xudong.rao <xudong.rao@outlook.com>
 homepage: https://www.jiguang.cn
 


### PR DESCRIPTION
## 变更内容
- iOS JPush SDK 升级至 6.2.4，并同步 CocoaPods 与 Swift Package Manager 依赖
- 修复 iOS 前台通知在 unShow 开启时未调用 completion handler 的问题
- 插件版本升级至 3.5.6，并更新 README 与 CHANGELOG

## 验证结果
- flutter analyze 通过
- flutter test 通过，8 项测试全部通过
- flutter pub publish --dry-run 完成
- JPush 6.2.4 iOS 无签名构建通过

## 发布注意
- 发布 tag 前需再次确认 CocoaPods CDN 普通索引已可解析 6.2.4
- 缺少 iOS 真机前台通知链路验证